### PR TITLE
danger zone should use translations

### DIFF
--- a/Resources/stubs/resource-lang/en/form-yearly.stub
+++ b/Resources/stubs/resource-lang/en/form-yearly.stub
@@ -3,5 +3,6 @@
 return [
     'cancel' => 'Cancel',
     'title-placeholder' => 'Title',
+    'danger' => 'Danger Zone',
     'year-placeholder' => 'Year',
 ];

--- a/Resources/stubs/resource-lang/en/form.stub
+++ b/Resources/stubs/resource-lang/en/form.stub
@@ -3,4 +3,5 @@
 return [
     'cancel' => 'Cancel',
     'title-placeholder' => 'Title',
+    'danger' => 'Danger Zone',
 ];

--- a/Resources/views/components/form/form.blade.php
+++ b/Resources/views/components/form/form.blade.php
@@ -267,7 +267,7 @@
 
         <div class="card card-collapsed">
             <div class="card-header">
-                <h3 class="card-title">Danger Zone</h3>
+                <h3 class="card-title">@lang((isset($namespace) ? "${namespace}::" : '') . 'form.danger')</h3>
                 <div class="card-options">
                     <a href="#" class="card-options-collapse" data-toggle="card-collapse"><i class="fe fe-chevron-up"></i></a>
                 </div>


### PR DESCRIPTION
`major` because existing projects will have a missing lang string without extra work